### PR TITLE
Updates after first implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ params:
   name: ""
   role: ""
   httpPort: ""
+  healthCheckPath: ""
   image: ""
-  trigger_jenkins_job: ""
-  starlord: true
+  slackChannel: ""
 ```
 
 > You can also provide param values by passing `--set name=value` to the

--- a/bootstrap-templates/default/.truss-manifest.yaml
+++ b/bootstrap-templates/default/.truss-manifest.yaml
@@ -17,6 +17,6 @@ params:
   - name: image
     type: string
     prompt: What is the name of your Docker image? Don't include any tags (i.e. 127178877223.dkr.ecr.us-east-2.amazonaws.com/my-app)
-  - name: slack_channel
+  - name: slackChannel
     type: string
     prompt: What Slack channel do you want to use for Spinnaker notifications (i.e. #my-app-alerts)

--- a/bootstrap-templates/default/README.md
+++ b/bootstrap-templates/default/README.md
@@ -185,8 +185,8 @@ jobs:
     name: Build & Deploy
     runs-on: ubuntu-latest
     env:
-      ECR_AWS_ACCESS_KEY_ID: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
-      ECR_AWS_SECRET_ACCESS_KEY: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+      ECR_AWS_ACCESS_KEY_ID: {{ "${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}" }}
+      ECR_AWS_SECRET_ACCESS_KEY: {{ "${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}" }}
       ECR_AWS_DEFAULT_REGION: us-east-2
     steps:
       - name: Checkout repo
@@ -196,7 +196,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: get-bridge/actions
-          token: ${{ secrets.GIT_HUB_TOKEN }}
+          token: {{ "${{ secrets.GIT_HUB_TOKEN }}" }}
           path: .github/actions
 
       - name: Login to ECR
@@ -204,18 +204,18 @@ jobs:
 
       - uses: docker/build-push-action@v3
         env:
-          IMAGE_REPO: ${{ env.ECR_REGISTRY }}/{{ .Params.name }}
+          IMAGE_REPO: {{ "${{ env.ECR_REGISTRY }}" }}/{{ .Params.name }}
         with:
           tags:  |
-            ${{ env.IMAGE_REPO }}:${{ github.sha }}
-            ${{ env.IMAGE_REPO }}:latest
+            {{ "${{ env.IMAGE_REPO }}:${{ github.sha }}" }}
+            {{ "${{ env.IMAGE_REPO }}:latest" }}
           push: true
 
       - name: Trigger Spinnaker Deploy
         uses: get-bridge/spinnaker-webhook@v2
         env:
-          SPINNAKER_WEBHOOK_HOST: ${{ secrets.SPINNAKER_HOST }}
-          SPINNAKER_WEBHOOK_TOKEN: ${{ secrets.SPINNAKER_TRIGGER_TOKEN }}
+          SPINNAKER_WEBHOOK_HOST: {{ "${{ secrets.SPINNAKER_HOST }}" }}
+          SPINNAKER_WEBHOOK_TOKEN: {{ "${{ secrets.SPINNAKER_TRIGGER_TOKEN }}" }}
           SPINNAKER_WEBHOOK_NAME: {{ .Params.name }}-service-github
 ```
 

--- a/bootstrap-templates/default/README.md
+++ b/bootstrap-templates/default/README.md
@@ -86,12 +86,142 @@ aws-vault exec bridge -- truss secrets push --all
 
 ### Adding an RDS database
 
-TODO
+TODO, but will use (Pier's Aurora TF module)[https://github.com/get-bridge/bridge-pier-aurora-module].
 
 ### Adding a Promotion Pipeline
 
-TODO
+After creating each workspace's pipeline in the `{{ .TrussDir }}/deploy/` directory,
+you will likely want to add a promotion pipeline, which will allow you to trigger a
+single pipeline that will in turn deploy to Edge, then Staging, then Production while
+validating that each environment is behaving correctly by running your smoketests.
+
+To add the promotion pipeline, in `{{ .TrussDir }}/common/spinnaker.tf`, uncomment the
+`promotion-pipeline` module at the bottom of the file.
+
+Then, re-apply the Terraform as follows:
+
+```shell
+cd {{ .TrussDir }}/common
+
+aws-vault exec bridge -- terraform init
+aws-vault exec bridge -- terraform plan
+
+# Review the plan, and if everything looks good...
+aws-vault exec bridge -- terraform apply
+```
+
+You will now find your promotion pipeline located at:
+https://prod.spinnaker.bridgeops.sh/#/applications/{{ .Params.name }}/executions?pipeline=Promote%20{{ .Params.name }}
+
+See the [bridge-spinnaker-promote-pipeline module docs](https://github.com/get-bridge/bridge-terraform-modules/tree/master/bridge-spinnaker-promote-pipeline) for more information about available options including manual judgements, notifications, etc.
 
 ### Triggering Spinnaker Pipelines from Github Actions
 
-TODO
+Whether you want to add a promotion pipeline or simply trigger a single pipeline,
+such as edge-cmh for a new service not yet deployed to Staging or Production, the
+process is similar.
+
+If you are NOT using a promotion pipeline, you'll need to enable a webhook trigger
+on the single pipeline(s) that you'll be calling. In `{{ .TrussDir }}/deploy/spinnaker.tf`,
+you'll need to uncomment the `terraform_remote_state` data resource at the top of the
+file, which will be used to obtain the webhook token that was generated in the set of
+`common` Terraform. You'll also need to uncomment the `trigger_webhook_source` and
+`trigger_webhook_payload_constraints` arguments to the `deploy-pipeline` module. Once
+you've made these changes, you'll need to apply them in any workspace whose pipeline you'd
+like to trigger:
+
+```shell
+cd {{ .TrussDir }}/deploy
+
+aws-vault exec bridge -- terraform init
+aws-vault exec bridge -- terraform workspace select <env>-<region> # e.g. edge-cmh
+aws-vault exec bridge -- terraform plan
+
+# Review the plan, and if everything looks good...
+aws-vault exec bridge -- terraform apply
+```
+
+No matter which pipeline you'd like to trigger, you'll need to add the webhook
+token as a secret to your Github repository and update your Github workflow to
+send a webhook to Spinnaker.
+
+First, make sure that you have a Github Personal Access Token with read-write permission
+to manage repository secrets set in a `GITHUB_TOKEN` environment variable.
+
+To add the token, in `{{ .Trussdir}}/common/spinnaker.tf`, uncomment the `github_actions_secret`
+resource above the `promotion-pipeline` module. **NOTE**: Please be certain that the `repository`
+indicated in this resource is the one you want to set the secret on. If the repo name is wrong,
+you will overwrite the wrong secret and break CD for someone else! Once uncommented, re-apply
+the `common` Terraform:
+
+```shell
+# Ensure that GITHUB_TOKEN is set...
+echo $GITHUB_TOKEN
+
+cd {{ .TrussDir }}/common
+
+aws-vault exec bridge -- terraform init
+aws-vault exec bridge -- terraform plan
+
+# Review the plan, and if everything looks good...
+aws-vault exec bridge -- terraform apply
+```
+
+The details of building a Docker image for your service are up to you, but you will want
+a Github Actions Workflow that builds your image, pushes it to EC2 Container Registry, and
+then triggers a deployment in Spinnaker via webhook. An example of such a workflow is:
+
+```yaml
+# .github/workflows/build.yaml
+name: Build & Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-image:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    env:
+      ECR_AWS_ACCESS_KEY_ID: ${{ secrets.TRUSS_AWS_ACCESS_KEY_ID }}
+      ECR_AWS_SECRET_ACCESS_KEY: ${{ secrets.TRUSS_AWS_SECRET_ACCESS_KEY }}
+      ECR_AWS_DEFAULT_REGION: us-east-2
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Checkout actions repo
+        uses: actions/checkout@v3
+        with:
+          repository: get-bridge/actions
+          token: ${{ secrets.GIT_HUB_TOKEN }}
+          path: .github/actions
+
+      - name: Login to ECR
+        uses: ./.github/actions/ecr-auth
+
+      - uses: docker/build-push-action@v3
+        env:
+          IMAGE_REPO: ${{ env.ECR_REGISTRY }}/{{ .Params.name }}
+        with:
+          tags:  |
+            ${{ env.IMAGE_REPO }}:${{ github.sha }}
+            ${{ env.IMAGE_REPO }}:latest
+          push: true
+
+      - name: Trigger Spinnaker Deploy
+        uses: get-bridge/spinnaker-webhook@v2
+        env:
+          SPINNAKER_WEBHOOK_HOST: ${{ secrets.SPINNAKER_HOST }}
+          SPINNAKER_WEBHOOK_TOKEN: ${{ secrets.SPINNAKER_TRIGGER_TOKEN }}
+          SPINNAKER_WEBHOOK_NAME: {{ .Params.name }}-service-github
+```
+
+With such a workflow in place, merging to your repo's `main` branch should now build your
+application's container image as specified by your `Dockerfile`, push it to EC2 Container
+Registry, and send a webhook to Spinnaker, handing it off to be deployed by your pipeline
+of choice.
+
+See the (spinnaker-webhook Action's docs)[https://github.com/get-bridge/spinnaker-webhook] for more options.

--- a/bootstrap-templates/default/common/output.tf
+++ b/bootstrap-templates/default/common/output.tf
@@ -1,0 +1,4 @@
+output "spinnaker_webhook_token" {
+  value     = random_password.webhook_token.result
+  sensitive = true
+}

--- a/bootstrap-templates/default/common/spinnaker.tf
+++ b/bootstrap-templates/default/common/spinnaker.tf
@@ -1,20 +1,3 @@
-# Uncomment to generate a random token to use when triggering Spinnaker
-# pipelines from Github Actions. Make sure `repository` is set correctly
-# in the `github_actions_secret`. If not, you may overwrite another repo's
-# secret by accident.
-#
-# resource "random_password" "webhook_token" {
-#   length  = 32
-#   special = false
-# }
-
-# resource "github_actions_secret" "spinnaker_token" {
-#   #
-#   repository      = "{{ .Params.name }}"
-#   secret_name     = "SPINNAKER_TRIGGER_TOKEN"
-#   plaintext_value = random_password.webhook_token.result
-# }
-
 resource "spinnaker_application" "application" {
   name  = "{{ .Params.name }}"
   email = "bridge-engineering-all@getbridge.com"
@@ -25,3 +8,78 @@ resource "spinnaker_application" "application" {
     execute = ["bridge-engineering-all"]
   }
 }
+
+resource "random_password" "webhook_token" {
+  length  = 32
+  special = false
+}
+
+# Uncomment this resource if you will be triggering Spinnaker pipelines
+# from Github Actions
+#
+# resource "github_actions_secret" "spinnaker_token" {
+#   repository      = "{{ .Params.name }}"
+#   secret_name     = "SPINNAKER_TRIGGER_TOKEN"
+#   plaintext_value = random_password.webhook_token.result
+# }
+
+# Uncomment the module below to add a promotion pipeline
+#
+# module "promotion-pipeline" {
+#   source = "git@github.com:get-bridge/bridge-terraform-modules.git//bridge-spinnaker-promote-pipeline"
+
+#   service = "{{ .Params.name }}"
+
+#   parameters = {
+#     sha = {
+#       default     = null
+#       description = "Git commit SHA"
+#       label       = null
+#       required    = true
+#     }
+#     message = {
+#       default     = null
+#       description = "Git commit message"
+#       label       = null
+#       required    = true
+#     }
+#     committer_name = {
+#       default     = null
+#       description = "Git committer name"
+#       label       = null
+#       required    = true
+#     }
+#     committer_email = {
+#       default     = null
+#       description = "Git committer email"
+#       label       = null
+#       required    = true
+#     }
+#   }
+
+#   # Configure Trigger
+#   trigger_webhook_source              = "{{ .Params.name }}-github"
+#   trigger_webhook_payload_constraints = { token = random_password.webhook_token.result }
+
+#   # Configure Edge
+#   edge_pipelines        = [for r in ["cmh"] : "Deploy api ${r}-edge"]
+#   edge_manual_judgement = false
+
+#   # Configure Staging
+#   staging_pipelines        = [for r in ["cmh", "dub", "syd"] : "Deploy api ${r}-staging"]
+#   staging_manual_judgement = false
+
+#   # Configure Prod
+#   prod_pipelines        = [for r in ["cmh", "dub", "syd"] : "Deploy api ${r}-prod"]
+#   prod_manual_judgement = false
+
+#   # Configure Slack Notifications
+#   slack_channel         = "{{ .Params.slackChannel }}"
+#   slack_pipeline_alerts = true
+#   complete_message      = "Promotion Completed"
+#   failed_message        = "Promotion Failed"
+#   starting_message      = "Starting Promotion"
+
+#   # Configure Manual Judgement Notifications
+#   slack_judgement_prompts = false
+# }

--- a/bootstrap-templates/default/deploy/kustomize.tf
+++ b/bootstrap-templates/default/deploy/kustomize.tf
@@ -1,6 +1,6 @@
 locals {
   vault_path = "vault:secret/data/bridge/${local.app_env}/${local.region}/{{ .Params.name }}/{{ .Params.role }}/default"
-  hostname   = "hello-jdharrington-${local.app_env}.${local.truss_env}-${local.region}.truss.bridgeops.sh"
+  hostname   = "{{ .Params.name }}-${local.app_env}.${local.truss_env}-${local.region}.truss.bridgeops.sh"
 }
 
 data "kustomization_overlay" "{{ .Params.name }}" {

--- a/bootstrap-templates/default/deploy/kustomize/poddisruptionbudget-{{ .Params.role }}.yaml
+++ b/bootstrap-templates/default/deploy/kustomize/poddisruptionbudget-{{ .Params.role }}.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Params.name }}-{{ .Params.role }}

--- a/bootstrap-templates/default/deploy/spinnaker.tf
+++ b/bootstrap-templates/default/deploy/spinnaker.tf
@@ -1,3 +1,6 @@
+# Uncomment this if you'll be triggering individual pipelines from Github
+# Actions. This is NOT necessary if you'll be using a promotion pipeline.
+#
 # data "terraform_remote_state" "common" {
 #   backend = "s3"
 #   config = {
@@ -48,6 +51,9 @@ module "deploy-pipeline" {
   # migrations are broken out into a separate step.
   health_check_initial_delay = 0
 
+  # Uncomment this if you'll be triggering individual pipelines from Github
+  # Actions. This is NOT necessary if you'll be using a promotion pipeline.
+  #
   # trigger_webhook_source = "{{ .Params.name }}-github"
   # trigger_webhook_payload_constraints = {
   #   token = data.terraform_remote_state.common.outputs.spinnaker_webhook_token

--- a/bootstrap-templates/default/deploy/spinnaker.tf
+++ b/bootstrap-templates/default/deploy/spinnaker.tf
@@ -53,7 +53,7 @@ module "deploy-pipeline" {
   #   token = data.terraform_remote_state.common.outputs.spinnaker_webhook_token
   # }
 
-  slack_channel      = "{{ .Params.slack_channel }}"
+  slack_channel      = "{{ .Params.slackChannel }}"
   enable_manual_gate = false
 
   failed_message   = "`${local.region}-${local.app_env}` pipeline has failed. $${trigger['parameters']['committer_name']} ($${trigger['parameters']['committer_email']}) `$${trigger['parameters']['message']}` ($${trigger['parameters']['sha']})"


### PR DESCRIPTION
This contains a few small fixes that fell out of implementing the new bootstrap template for bridge-skills-service, and also adds docs for creating a Spinnaker promotion pipeline and wiring it up to Github Actions.