### PR TITLE
update goreleaser manifest by replacing deprecated name_template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[{Makefile,go.mod,go.sum,*.go,.gitmodules}]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+eclint_indent_style = unset
+
+[Dockerfile]
+indent_size = 4
+

--- a/.github/workflows/bootstrap-templates.yml
+++ b/.github/workflows/bootstrap-templates.yml
@@ -1,23 +1,23 @@
 name: Publish
 on:
   push:
-    tags: ['*']
-    branches: ['bootstrapper']
+    tags: ["*"]
+    branches: ["bootstrapper"]
 
 jobs:
   # The publish job will publish the bootstrap-templates directory to the correct S3 Bucket
   publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: jakejarvis/s3-sync-action@master
-      with:
-        args: --acl private --follow-symlinks
-      env:
-        # Credentials for this workflow are provisioned in the `terraform` directory
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        AWS_S3_BUCKET: truss-cli-global-config
-        AWS_REGION: us-east-2
-        SOURCE_DIR: bootstrap-templates
-        DEST_DIR: bootstrap-templates
+      - uses: actions/checkout@master
+      - uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl private --follow-symlinks
+        env:
+          # Credentials for this workflow are provisioned in the `terraform` directory
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_S3_BUCKET: truss-cli-global-config
+          AWS_REGION: us-east-2
+          SOURCE_DIR: bootstrap-templates
+          DEST_DIR: bootstrap-templates

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.19
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.21"
 
-    - name: Go test
-      run: go test ./cmd/ ./truss/ -timeout 15000ms
+      - name: Go test
+        run: go test ./cmd/ ./truss/ -timeout 15000ms

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Release
 # Controls when the action will run. Triggers the workflow on push or pull request
 on:
   push:
-    tags: ['*']
+    tags: ["*"]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -16,24 +16,24 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
 
-    # Unshallow required for goreleaser's changelog behavior
-    - name: Unshallow
-      run: git fetch --prune --unshallow
+      # Unshallow required for goreleaser's changelog behavior
+      - name: Unshallow
+        run: git fetch --prune --unshallow
 
-    # Go get'em!
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.19
+      # Go get'em!
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.21"
 
-    # Release the thing!
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v2
-      with:
-        version: latest
-        args: release --rm-dist
-      env:
-        GITHUB_TOKEN: ${{ secrets.INSTRUCTURE_BRIDGE_GITHUB_BOT_REPO_RW }}
+      # Release the thing!
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: "1.23"
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.INSTRUCTURE_BRIDGE_GITHUB_BOT_REPO_RW }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,11 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
 
 dist/
 .envrc
+.env
 
 # Secrets
 /secrets

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,15 +31,6 @@ archives:
       - goos: windows
         format: zip
 
-archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-    arm64: arm64
-
 checksum:
   name_template: 'checksums.txt'
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,17 +4,17 @@ before:
     - go generate ./...
 
 builds:
-- env:
-  - CGO_ENABLED=0
-  ldflags:
-    - -X github.com/get-bridge/truss-cli/cmd.Version={{.Version}}
-  binary: truss
-  goos:
-    - darwin
-    - linux
-  goarch:
-    - amd64
-    - arm64
+  - env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/get-bridge/truss-cli/cmd.Version={{.Version}}
+    binary: truss
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - format: tar.gz
@@ -32,7 +32,7 @@ archives:
         format: zip
 
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 
 snapshot:
   name_template: "{{ .Tag }}-next"
@@ -41,16 +41,15 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - "^docs:"
+      - "^test:"
 brews:
-  -
-    name: truss-cli
+  - name: truss-cli
     description: CLI to help manage many k8s clusters
     homepage: https://github.com/get-bridge/truss-cli
-    tap:
-      owner: get-bridge
-      name: homebrew-tap
+    repository:
+      - name: homebrew-tap
+        owner: get-bridge
     folder: Formula
     dependencies:
       - name: kubectl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,6 +2,7 @@ before:
   hooks:
     - go mod download
     - go generate ./...
+
 builds:
 - env:
   - CGO_ENABLED=0
@@ -14,6 +15,22 @@ builds:
   goarch:
     - amd64
     - arm64
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
 archives:
 - replacements:
     darwin: Darwin
@@ -22,10 +39,13 @@ archives:
     386: i386
     amd64: x86_64
     arm64: arm64
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .Tag }}-next"
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,8 +48,8 @@ brews:
     description: CLI to help manage many k8s clusters
     homepage: https://github.com/get-bridge/truss-cli
     repository:
-      - name: homebrew-tap
-        owner: get-bridge
+      name: homebrew-tap
+      owner: get-bridge
     folder: Formula
     dependencies:
       - name: kubectl


### PR DESCRIPTION
The manifest's `archives.replacements` was deprecated since 2022-11-24 (v1.14.0), removed 2023-06-06 (v1.19.0)
- [link](https://goreleaser.com/deprecations/#archivesreplacements)

```
Run goreleaser/goreleaser-action@v[2](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:2)
  with:
    version: latest
    args: release --rm-dist
    distribution: goreleaser
    workdir: .
    install-only: false
  env:
    GOROOT: /opt/hostedtoolcache/go/1.19.1[3](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:3)/x6[4](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:4)
    GITHUB_TOKEN: ***
Downloading https://github.com/goreleaser/goreleaser/releases/download/v1.23.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/7bc32d00-8f49-4a08-84[5](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:5)9-b[6](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:6)6cefd1[7](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:7)636 -f /home/runner/work/_temp/fb65c10[8](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:8)-b5ef-4ccd-[9](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:9)81f-8c79ee2b4[17](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:18)a
GoReleaser latest installed successfully
v0.3.3 tag found for commit '3bd401e'
/opt/hostedtoolcache/goreleaser-action/1.23.0/x64/goreleaser release --rm-dist
Flag --rm-dist has been deprecated, please use --clean instead
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line [18](https://github.com/get-bridge/truss-cli/actions/runs/7486947297/job/20378903703#step:5:19): field replacements not found in type config.Archive
Error: The process '/opt/hostedtoolcache/goreleaser-action/1.23.0/x64/goreleaser' failed with exit code 1
```
